### PR TITLE
Add validation for client_id (aud) in message launch

### DIFF
--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -288,6 +288,11 @@ class LTI_Message_Launch {
         }
 
         $client_id = $this->get_client_id_from_jwt();
+
+        if (empty($client_id)) {
+            throw new LTI_Exception('Invalid client id', 1);
+        }
+        
         // Find registration.
         $this->registration = $this->db->find_registration_by_issuer($this->jwt['body']['iss'], $client_id);
 

--- a/tests/unit/helpers/DummyDatabase.php
+++ b/tests/unit/helpers/DummyDatabase.php
@@ -39,8 +39,7 @@ class DummyDatabase implements Database {
                 return $registration;
             }
         }
-
-        throw new \Exception('Cannot find issuer details in registrations file');
+        return null;
     }
 
     public function find_deployment($iss, $deployment_id)


### PR DESCRIPTION
The library was not ensuring that lti message launch payloads had an `aud` property, which is required.

Because this has to be optional on `Database->find_registration_by_issuer()`, not checking for it adds unnecessary trip hazards for implementors.