### PR TITLE
ASP-2543: add logic to set client_id from $request[client_id]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,35 @@
 version: '3.7'
 services:
   composer:
-    image: composer:latest
+    image: composer:2.2
     environment:
       - COMPOSER_CACHE_DIR=/app/.cache/composer
     volumes:
       - .:/app
-    restart: never    
+    restart: never
   php55:
     image: php:5.5-cli
-    volumes: 
+    volumes:
       - .:/app
     working_dir: /app
     restart: never
   php70:
     image: php:7.0-cli
-    volumes: 
+    volumes:
       - .:/app
     working_dir: /app
-    restart: never    
+    restart: never
   phpunit55:
     image: php:5.5-cli
     restart: never
     volumes:
       - .:/app
     working_dir: /app
-    entrypoint: vendor/bin/phpunit    
+    entrypoint: vendor/bin/phpunit
   phpunit70:
     image: php:7.0-cli
     restart: never
     volumes:
       - .:/app
     working_dir: /app
-    entrypoint: vendor/bin/phpunit        
+    entrypoint: vendor/bin/phpunit

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace IMSGlobal\LTI;
 
 class LTI_OIDC_Login {
@@ -14,7 +15,8 @@ class LTI_OIDC_Login {
      * @param Cache    $cache    Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
      * @param Cookie   $cookie   Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.
      */
-    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
+    function __construct(Database $database, Cache $cache = null, Cookie $cookie = null)
+    {
         $this->db = $database;
         if ($cache === null) {
             $cache = new FileCache();
@@ -36,7 +38,8 @@ class LTI_OIDC_Login {
      *
      * @return LTI_OIDC_Login
      */
-    public static function newInstance(Database $database, Cache $cache = null, Cookie $cookie = null) {
+    public static function newInstance(Database $database, Cache $cache = null, Cookie $cookie = null)
+    {
         return new LTI_OIDC_Login($database, $cache, $cookie);
     }
 
@@ -48,7 +51,8 @@ class LTI_OIDC_Login {
      *
      * @return Redirect Returns a redirect object containing the fully formed OIDC login URL.
      */
-    public function do_oidc_login_redirect($launch_url, array $request = null) {
+    public function do_oidc_login_redirect($launch_url, array $request = null)
+    {
 
         if ($request === null) {
             $request = $_REQUEST;
@@ -100,7 +104,8 @@ class LTI_OIDC_Login {
 
     }
 
-    protected function validate_oidc_login($request) {
+    protected function validate_oidc_login($request)
+    {
 
         // Validate Issuer.
         if (empty($request['iss'])) {
@@ -112,9 +117,7 @@ class LTI_OIDC_Login {
             throw new OIDC_Exception("Could not find login hint", 1);
         }
 
-        // if request['aud'] use it, else try $request['client_id] else set to null;
-        $clientId = isset($request['aud']) ? $request['aud'] : null;
-        $clientId = (empty($clientId) && isset($request['client_id'])) ? $request['client_id'] : null;
+        $clientId = $this->getClientIdFromRequest($request);
 
         // Fetch Registration Details.
         $registration = $this->db->find_registration_by_issuer($request['iss'], $clientId);
@@ -126,5 +129,25 @@ class LTI_OIDC_Login {
 
         // Return Registration.
         return $registration;
+    }
+
+    /**
+     * Get the clientId from the request. If `client_id` and `aud` are present, then `client_id` has preference.
+     *
+     * @param array $request An array of request parameters.
+     *
+     * @return string|null
+     */
+    private function getClientIdFromRequest(array $request)
+    {
+        $clientId = null;
+
+        if (isset($request['client_id'])) {
+            $clientId = $request['client_id'];
+        } elseif (isset($request['aud'])) {
+            $clientId = $request['aud'];
+        }
+
+        return $clientId;
     }
 }

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -33,7 +33,7 @@ class LTI_OIDC_Login {
      * @param Database $database Instance of the database interface used for looking up registrations and deployments.
      * @param Cache    $cache    Instance of the Cache interface used to loading and storing launches. If non is provided launch data will be store in $_SESSION.
      * @param Cookie   $cookie   Instance of the Cookie interface used to set and read cookies. Will default to using $_COOKIE and setcookie.
-     * 
+     *
      * @return LTI_OIDC_Login
      */
     public static function newInstance(Database $database, Cache $cache = null, Cookie $cookie = null) {
@@ -112,7 +112,9 @@ class LTI_OIDC_Login {
             throw new OIDC_Exception("Could not find login hint", 1);
         }
 
+        // if request['aud'] use it, else try $request['client_id] else set to null;
         $clientId = isset($request['aud']) ? $request['aud'] : null;
+        $clientId = (empty($clientId) && isset($request['client_id'])) ? $request['client_id'] : null;
 
         // Fetch Registration Details.
         $registration = $this->db->find_registration_by_issuer($request['iss'], $clientId);

--- a/tests/unit/LTI_OIDC_Login_Test.php
+++ b/tests/unit/LTI_OIDC_Login_Test.php
@@ -155,7 +155,7 @@ class LTI_OIDC_Login_Test extends TestBase
             $request
         );
 
-        $expectedId = isset($request['aud']) ? $request['aud'] : $request['client_id'];
+        $expectedId = isset($request['client_id']) ? $request['client_id'] : $request['aud'];
 
         $this->assertInstanceOf(Redirect::class, $redirect);
 
@@ -182,6 +182,15 @@ class LTI_OIDC_Login_Test extends TestBase
                     'login_hint' => 'password123',
                     'lti_message_hint' => 'my message hint',
                     'aud' => 'aud_12345'
+                ]
+            ],
+            'clientId and aud present' => [
+                [
+                    'iss' => 'ccc',
+                    'login_hint' => 'password123',
+                    'lti_message_hint' => 'my message hint',
+                    'aud' => 'aud_12345',
+                    'client_id' => '12345'
                 ]
             ]
         ];

--- a/tests/unit/fixtures/registration_db.json
+++ b/tests/unit/fixtures/registration_db.json
@@ -5,6 +5,14 @@
         "deployment_id": "aaa-12345",
         "auth_login_url": "https://example.com/lti1p3/aaa/12345/auth_login_url",
         "auth_token_url": "https://example.com/lti1p3/aaa/12345/auth_token_url",
-        "key_set_url": "https://example.com/lti1p3/aaa/12345/key_set_url"                
+        "key_set_url": "https://example.com/lti1p3/aaa/12345/key_set_url"
+    },
+    {
+        "issuer": "bbb",
+        "aud": "aud_12345",
+        "deployment_id": "bbb-12345",
+        "auth_login_url": "https://example.com/lti1p3/bbb/aud_12345/auth_login_url",
+        "auth_token_url": "https://example.com/lti1p3/bbb/aud_12345/auth_token_url",
+        "key_set_url": "https://example.com/lti1p3/bbb/aud_12345/key_set_url"
     }
 ]

--- a/tests/unit/fixtures/registration_db.json
+++ b/tests/unit/fixtures/registration_db.json
@@ -14,5 +14,14 @@
         "auth_login_url": "https://example.com/lti1p3/bbb/aud_12345/auth_login_url",
         "auth_token_url": "https://example.com/lti1p3/bbb/aud_12345/auth_token_url",
         "key_set_url": "https://example.com/lti1p3/bbb/aud_12345/key_set_url"
+    },
+    {
+        "issuer": "ccc",
+        "aud": "aud_12345",
+        "client_id": "12345",
+        "deployment_id": "bbb-12345",
+        "auth_login_url": "https://example.com/lti1p3/bbb/aud_12345/auth_login_url",
+        "auth_token_url": "https://example.com/lti1p3/bbb/aud_12345/auth_token_url",
+        "key_set_url": "https://example.com/lti1p3/bbb/aud_12345/key_set_url"
     }
 ]

--- a/tests/unit/helpers/DummyDatabase.php
+++ b/tests/unit/helpers/DummyDatabase.php
@@ -6,7 +6,8 @@ use IMSGlobal\LTI\Database;
 use IMSGlobal\LTI\LTI_Registration;
 use IMSGlobal\LTI\LTI_Deployment;
 
-class DummyDatabase implements Database {
+class DummyDatabase implements Database
+{
     public function find_registration_by_issuer($iss, $clientId = null)
     {
         $privateKeyFileContents = file_get_contents(dirname(dirname(__FILE__)) . '/fixtures/private.key');
@@ -16,7 +17,10 @@ class DummyDatabase implements Database {
             $registrations = json_decode($registrationDBFile, true);
             foreach ($registrations as $registrationDetails) {
                 if ($registrationDetails['issuer'] === $iss) {
-                    if (empty($clientId) || $registrationDetails['client_id'] === $clientId) {
+                    if (empty($clientId)
+                        || $registrationDetails['client_id'] === $clientId
+                        || $registrationDetails['aud'] === $clientId
+                    ) {
                         $details = $registrationDetails;
                         break;
                     }
@@ -24,7 +28,7 @@ class DummyDatabase implements Database {
             }
             if (!empty($details)) {
                 if (empty($clientId)) {
-                    $clientId = $details['client_id'];                    
+                    $clientId = isset($details['client_id'])? $details['client_id'] : $details['aud'];
                 }
 
                 $registration = LTI_Registration::newInstance()
@@ -32,8 +36,8 @@ class DummyDatabase implements Database {
                     ->set_auth_token_url($details['auth_token_url'])
                     ->set_key_set_url($details['key_set_url'])
                     ->set_kid("key_{$iss}_{$clientId}")
-                    ->set_tool_private_key($privateKeyFileContents);                
-                
+                    ->set_tool_private_key($privateKeyFileContents);
+
 
                 $registration->set_client_id($clientId);
                 return $registration;


### PR DESCRIPTION
* https://github.com/talis/aspire/issues/2543

Adds support for `clientId` be passed in the request as `client_id` and not `aud`. Tests updated to reflect this.