### PR TITLE
Exception subtypes for clearer scenario targeting

### DIFF
--- a/src/lti/LTI_JWT_Exception.php
+++ b/src/lti/LTI_JWT_Exception.php
@@ -1,0 +1,6 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class LTI_JWT_Exception extends LTI_Exception {
+
+}

--- a/src/lti/LTI_Message_Validation_Exception.php
+++ b/src/lti/LTI_Message_Validation_Exception.php
@@ -1,0 +1,6 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class LTI_Message_Validation_Exception extends LTI_Exception {
+
+}

--- a/src/lti/LTI_No_State_Found_Exception.php
+++ b/src/lti/LTI_No_State_Found_Exception.php
@@ -1,0 +1,6 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class LTI_No_State_Found_Exception extends LTI_Exception {
+
+}

--- a/src/lti/LTI_Public_Key_Exception.php
+++ b/src/lti/LTI_Public_Key_Exception.php
@@ -1,0 +1,6 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class LTI_Public_Key_Exception extends LTI_Exception {
+
+}

--- a/src/lti/LTI_Registration_Exception.php
+++ b/src/lti/LTI_Registration_Exception.php
@@ -1,0 +1,6 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class LTI_Registration_Exception extends LTI_Exception {
+
+}

--- a/src/lti/message_validators/deep_link_message_validator.php
+++ b/src/lti/message_validators/deep_link_message_validator.php
@@ -8,26 +8,26 @@ class Deep_Link_Message_Validator implements Message_Validator {
 
     public function validate($jwt_body) {
         if (empty($jwt_body['sub'])) {
-            throw new LTI_Exception('Must have a user (sub)');
+            throw new LTI_Message_Validation_Exception('Must have a user (sub)');
         }
         if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
-            throw new LTI_Exception('Incorrect version, expected 1.3.0');
+            throw new LTI_Message_Validation_Exception('Incorrect version, expected 1.3.0');
         }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
-            throw new LTI_Exception('Missing Roles Claim');
+            throw new LTI_Message_Validation_Exception('Missing Roles Claim');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'])) {
-            throw new LTI_Exception('Missing Deep Linking Settings');
+            throw new LTI_Message_Validation_Exception('Missing Deep Linking Settings');
         }
         $deep_link_settings = $jwt_body['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'];
         if (empty($deep_link_settings['deep_link_return_url'])) {
-            throw new LTI_Exception('Missing Deep Linking Return URL');
+            throw new LTI_Message_Validation_Exception('Missing Deep Linking Return URL');
         }
         if (empty($deep_link_settings['accept_types']) || !in_array('ltiResourceLink', $deep_link_settings['accept_types'])) {
-            throw new LTI_Exception('Must support resource link placement types');
+            throw new LTI_Message_Validation_Exception('Must support resource link placement types');
         }
         if (empty($deep_link_settings['accept_presentation_document_targets'])) {
-            throw new LTI_Exception('Must support a presentation type');
+            throw new LTI_Message_Validation_Exception('Must support a presentation type');
         }
 
         return true;

--- a/src/lti/message_validators/resource_message_validator.php
+++ b/src/lti/message_validators/resource_message_validator.php
@@ -8,16 +8,16 @@ class Resource_Message_Validator implements Message_Validator {
 
     public function validate($jwt_body) {
         if (empty($jwt_body['sub'])) {
-            throw new LTI_Exception('Must have a user (sub)');
+            throw new LTI_Message_Validation_Exception('Must have a user (sub)');
         }
         if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
-            throw new LTI_Exception('Incorrect version, expected 1.3.0');
+            throw new LTI_Message_Validation_Exception('Incorrect version, expected 1.3.0');
         }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
-            throw new LTI_Exception('Missing Roles Claim');
+            throw new LTI_Message_Validation_Exception('Missing Roles Claim');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'])) {
-            throw new LTI_Exception('Missing Resource Link Id');
+            throw new LTI_Message_Validation_Exception('Missing Resource Link Id');
         }
 
         return true;

--- a/src/lti/message_validators/submission_review_message_validator.php
+++ b/src/lti/message_validators/submission_review_message_validator.php
@@ -8,19 +8,19 @@ class Submission_Review_Message_Validator implements Message_Validator {
 
     public function validate($jwt_body) {
         if (empty($jwt_body['sub'])) {
-            throw new LTI_Exception('Must have a user (sub)');
+            throw new LTI_Message_Validation_Exception('Must have a user (sub)');
         }
         if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
-            throw new LTI_Exception('Incorrect version, expected 1.3.0');
+            throw new LTI_Message_Validation_Exception('Incorrect version, expected 1.3.0');
         }
         if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
-            throw new LTI_Exception('Missing Roles Claim');
+            throw new LTI_Message_Validation_Exception('Missing Roles Claim');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'])) {
-            throw new LTI_Exception('Missing Resource Link Id');
+            throw new LTI_Message_Validation_Exception('Missing Resource Link Id');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/for_user'])) {
-            throw new LTI_Exception('Missing For User');
+            throw new LTI_Message_Validation_Exception('Missing For User');
         }
 
         return true;

--- a/tests/unit/LTI_Message_Launch_Test.php
+++ b/tests/unit/LTI_Message_Launch_Test.php
@@ -4,7 +4,11 @@ namespace IMSGlobal\LTI\Tests\unit;
 
 use Firebase\JWT\JWT;
 use IMSGlobal\LTI\Cookie;
+use IMSGlobal\LTI\LTI_JWT_Exception;
 use IMSGlobal\LTI\LTI_Message_Launch;
+use IMSGlobal\LTI\LTI_Message_Validation_Exception;
+use IMSGlobal\LTI\LTI_No_State_Found_Exception;
+use IMSGlobal\LTI\LTI_Registration_Exception;
 use IMSGlobal\LTI\Tests\unit\helpers\DummyDatabase;
 use IMSGlobal\LTI\Tests\unit\helpers\InMemoryCache;
 
@@ -32,7 +36,7 @@ class LTI_Message_Launch_Test extends TestBase {
 
     public function testValidateStateWithInvalidStateThrowsException()
     {
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'State not found');
+        $this->setExpectedException(LTI_No_State_Found_Exception::class, 'State not found');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -50,7 +54,7 @@ class LTI_Message_Launch_Test extends TestBase {
     public function testValidateState()
     {
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Missing id_token');
+        $this->setExpectedException(LTI_JWT_Exception::class, 'Missing id_token');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -68,7 +72,7 @@ class LTI_Message_Launch_Test extends TestBase {
     {
         $jwt = $this->encodeJWT($this->getValidJWTPayload());
         $state = uniqid();
-        $this->setExpectedException('\Exception', 'Invalid signature on id_token');
+        $this->setExpectedException(LTI_JWT_Exception::class, 'Invalid signature on id_token');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -93,7 +97,7 @@ class LTI_Message_Launch_Test extends TestBase {
     {
         $jwt = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhYWEiLCJhdWQiOiIxMjM0NSJ9';
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Invalid id_token, JWT must contain 3 parts');
+        $this->setExpectedException(LTI_JWT_Exception::class, 'Invalid id_token, JWT must contain 3 parts');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -112,7 +116,7 @@ class LTI_Message_Launch_Test extends TestBase {
         $badKey = openssl_pkey_new();
         $jwt = $this->encodeJWT($this->getValidJWTPayload(), $badKey);
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Invalid signature on id_token');
+        $this->setExpectedException(LTI_JWT_Exception::class, 'Invalid signature on id_token');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -139,7 +143,7 @@ class LTI_Message_Launch_Test extends TestBase {
         $payload['aud'] = '67890';
         $jwt = $this->encodeJWT($payload);
         $state = uniqid();
-        $this->setExpectedException('\Exception', 'Registration not found.');
+        $this->setExpectedException(LTI_Registration_Exception::class, 'Registration not found.');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -174,7 +178,7 @@ class LTI_Message_Launch_Test extends TestBase {
 
         $jwt = $this->encodeJWT($payload);
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Registration not found');
+        $this->setExpectedException(LTI_Registration_Exception::class, 'Registration not found');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -199,7 +203,7 @@ class LTI_Message_Launch_Test extends TestBase {
 
         $jwt = $this->encodeJWT($payload);
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Invalid client id');
+        $this->setExpectedException(LTI_Registration_Exception::class, 'Invalid client id');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -223,7 +227,7 @@ class LTI_Message_Launch_Test extends TestBase {
         $payload = $this->getValidJWTPayload();
         $jwtWithInvalidSignature = $this->encodeJWT($payload, $badKey);
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Invalid signature on id_token');
+        $this->setExpectedException(LTI_JWT_Exception::class, 'Invalid signature on id_token');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -307,7 +311,7 @@ class LTI_Message_Launch_Test extends TestBase {
         $payload['is_valid'] = false;
         $jwt = $this->encodeJWT($payload);
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Message validation failed');
+        $this->setExpectedException(LTI_Message_Validation_Exception::class, 'Message validation failed');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])
@@ -345,7 +349,7 @@ class LTI_Message_Launch_Test extends TestBase {
 
         $jwt = $this->encodeJWT($payload);
         $state = uniqid();
-        $this->setExpectedException('\IMSGlobal\LTI\LTI_Exception', 'Validator conflict');
+        $this->setExpectedException(LTI_Message_Validation_Exception::class, 'Validator conflict');
         /** @var Cookie|\PHPUnit_Framework_MockObject_MockObject $cookie */
         $cookie = $this->getMockBuilder(Cookie::class)
             ->setMethods(['get_cookie'])

--- a/tests/unit/LTI_OIDC_Login_Test.php
+++ b/tests/unit/LTI_OIDC_Login_Test.php
@@ -4,6 +4,7 @@ namespace IMSGlobal\LTI\Tests\unit;
 
 use IMSGlobal\LTI\Cookie;
 use IMSGlobal\LTI\LTI_OIDC_Login;
+use IMSGlobal\LTI\OIDC_Exception;
 use IMSGlobal\LTI\Redirect;
 use IMSGlobal\LTI\Tests\unit\helpers\DummyDatabase;
 use IMSGlobal\LTI\Tests\unit\helpers\InMemoryCache;
@@ -21,14 +22,14 @@ class LTI_OIDC_Login_Test extends TestBase
 
     public function testDoOidcLoginRedirectEmptyLaunchUrl()
     {
-        $this->setExpectedException('IMSGlobal\LTI\OIDC_Exception', 'No launch URL configured');
+        $this->setExpectedException(OIDC_Exception::class, 'No launch URL configured');
 
         LTI_OIDC_Login::newInstance(new DummyDatabase())->do_oidc_login_redirect('');
     }
 
     public function testValidateOidcLoginNoIssuer()
     {
-        $this->setExpectedException('IMSGlobal\LTI\OIDC_Exception', 'Could not find issuer');
+        $this->setExpectedException(OIDC_Exception::class, 'Could not find issuer');
         LTI_OIDC_Login::newInstance(new DummyDatabase())->do_oidc_login_redirect(
             $this->launchUrl,
             []
@@ -37,7 +38,7 @@ class LTI_OIDC_Login_Test extends TestBase
 
     public function testValidateOidcLoginNoPasswordHint()
     {
-        $this->setExpectedException('IMSGlobal\LTI\OIDC_Exception', 'Could not find login hint');
+        $this->setExpectedException(OIDC_Exception::class, 'Could not find login hint');
         LTI_OIDC_Login::newInstance(new DummyDatabase())->do_oidc_login_redirect(
             $this->launchUrl,
             ['iss' => 'aaa']
@@ -46,7 +47,7 @@ class LTI_OIDC_Login_Test extends TestBase
 
     public function testValidateOidcLoginRegistrationNotFound()
     {
-        $this->setExpectedException('IMSGlobal\LTI\OIDC_Exception', 'Could not find registration details');
+        $this->setExpectedException(OIDC_Exception::class, 'Could not find registration details');
 
         /** @var DummyDatabase|\PHPUnit_Framework_MockObject_MockObject */
         $registrationDatabase = $this->getMockBuilder(DummyDatabase::class)

--- a/tests/unit/message_validators/Deep_Link_Message_Validator_Test.php
+++ b/tests/unit/message_validators/Deep_Link_Message_Validator_Test.php
@@ -6,6 +6,7 @@ include_once dirname(dirname(dirname(dirname(__FILE__)))) . '/src/lti/message_va
 
 use IMSGlobal\LTI\Deep_Link_Message_Validator;
 use IMSGlobal\LTI\LTI_Exception;
+use IMSGlobal\LTI\LTI_Message_Validation_Exception;
 use IMSGlobal\LTI\Tests\unit\TestBase;
 
 class Deep_Link_Message_Validator_Test extends TestBase {
@@ -62,7 +63,7 @@ class Deep_Link_Message_Validator_Test extends TestBase {
      */
     public function testValidateJwtBody($propertyToReplace, $replacementValue, $expectedExceptionMessage)
     {
-        $this->setExpectedException('IMSGlobal\LTI\LTI_Exception', $expectedExceptionMessage);
+        $this->setExpectedException(LTI_Message_Validation_Exception::class, $expectedExceptionMessage);
 
         $validator = new Deep_Link_Message_Validator();
         $this->jwtBody[$propertyToReplace] = $replacementValue;
@@ -96,7 +97,7 @@ class Deep_Link_Message_Validator_Test extends TestBase {
      */
     public function testValidateDeepLinkingSettings($propertyToReplace, $replacementValue, $expectedExceptionMessage)
     {
-        $this->setExpectedException('IMSGlobal\LTI\LTI_Exception', $expectedExceptionMessage);
+        $this->setExpectedException(LTI_Message_Validation_Exception::class, $expectedExceptionMessage);
 
         $validator = new Deep_Link_Message_Validator();
         $this->jwtBody['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'][$propertyToReplace] = $replacementValue;

--- a/tests/unit/message_validators/Resource_Message_Validator_Test.php
+++ b/tests/unit/message_validators/Resource_Message_Validator_Test.php
@@ -4,6 +4,7 @@ namespace IMSGlobal\LTI\Tests\unit\message_validators;
 
 include_once dirname(dirname(dirname(dirname(__FILE__)))) . '/src/lti/message_validators/resource_message_validator.php';
 
+use IMSGlobal\LTI\LTI_Message_Validation_Exception;
 use IMSGlobal\LTI\Resource_Message_Validator;
 use IMSGlobal\LTI\Tests\unit\TestBase;
 
@@ -59,7 +60,7 @@ class Resource_Message_Validator_Test extends TestBase {
      */
     public function testValidateJwtBody($propertyToReplace, $replacementValue, $expectedExceptionMessage)
     {
-        $this->setExpectedException('IMSGlobal\LTI\LTI_Exception', $expectedExceptionMessage);
+        $this->setExpectedException(LTI_Message_Validation_Exception::class, $expectedExceptionMessage);
 
         $validator = new Resource_Message_Validator();
         $this->jwtBody[$propertyToReplace] = $replacementValue;


### PR DESCRIPTION
1. Adds specific exception subtypes to allow us to differentiate different kinds of exception
2. Removes error codes, since they're all `1`
3. Updates tests to use `::class` for mocking.