### PR TITLE
PLT-244 Remove setcookie hack for PHP 7.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,16 @@
 version: 2.1
 
 jobs:
-  linting:
+  test:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:2023.10.1
     steps:
       - checkout
       - run: docker-compose run composer install
-      - run: docker-compose run php70 ./vendor/bin/phpcs ./src
-  test-php55:
-    machine:  
-      image: ubuntu-2004:202107-02    
-    steps:
-      - checkout
-      - run: docker-compose run composer install
-      - run: docker-compose run phpunit55 tests/unit
-  test-php70:
-    machine:  
-      image: ubuntu-2004:202107-02    
-    steps:
-      - checkout
-      - run: docker-compose run composer install
-      - run: docker-compose run phpunit70 tests/unit      
+      - run: docker-compose run php73 ./vendor/bin/phpcs ./src
+      - run: docker-compose run phpunit73 tests/unit
 
 workflows:
   build_and_test:
-    jobs:    
-      - linting
-      - test-php55:
-          requires:
-            - linting
-      - test-php70:
-          requires:
-            - linting      
+    jobs:
+      - test

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,10 @@
     "name": "talis/lti-1p3-php-library",
     "type": "library",
     "require": {
+        "php": ">=7.3.0",
         "fproject/php-jwt": "^4.0",
         "phpseclib/phpseclib": "^2.0",
-        "paragonie/random_compat": "<9.99"
+        "paragonie/random_compat": "~1.0|~2.0|~9.99"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.36",
@@ -14,13 +15,10 @@
         "psr-4": {
             "IMSGlobal\\LTI\\": "src/lti"
         }
-    },    
+    },
     "autoload-dev": {
-      "psr-4": { "IMSGlobal\\LTI\\Tests\\": "tests/" }
-    },    
-    "config": {
-        "platform": {
-            "php": "5.5.9"
+        "psr-4": {
+            "IMSGlobal\\LTI\\Tests\\": "tests/"
         }
     },
     "authors": [
@@ -28,5 +26,9 @@
             "name": "Martin Lenord",
             "email": "ims.m@rtin.dev"
         }
-    ]
+    ],
+    "scripts": {
+        "lint": "phpcs src",
+        "test": "phpunit tests/unit"
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,20 @@
 version: '3.7'
 services:
   composer:
-    image: composer:2.2
+    image: composer:2.6
     environment:
       - COMPOSER_CACHE_DIR=/app/.cache/composer
     volumes:
       - .:/app
     restart: never
-  php55:
-    image: php:5.5-cli
+  php73:
+    image: php:7.3-cli
     volumes:
       - .:/app
     working_dir: /app
     restart: never
-  php70:
-    image: php:7.0-cli
-    volumes:
-      - .:/app
-    working_dir: /app
-    restart: never
-  phpunit55:
-    image: php:5.5-cli
-    restart: never
-    volumes:
-      - .:/app
-    working_dir: /app
-    entrypoint: vendor/bin/phpunit
-  phpunit70:
-    image: php:7.0-cli
+  phpunit73:
+    image: php:7.3-cli
     restart: never
     volumes:
       - .:/app

--- a/src/lti/Cookie.php
+++ b/src/lti/Cookie.php
@@ -4,10 +4,10 @@ namespace IMSGlobal\LTI;
 class Cookie {
     /**
      * Get a cookie, if defined. Will look for the $name prefixed with "LEGACY_" if not found
-     * 
+     *
      * @param string $name Cookie name
-     * 
-     * @return mixed|boolean 
+     *
+     * @return mixed|false Cookie value or false if not found
      */
     public function get_cookie($name) {
         if (isset($_COOKIE[$name])) {
@@ -22,13 +22,13 @@ class Cookie {
 
     /**
      * Sets a cookie
-     * 
+     *
      * @param string  $name    Cookie name
      * @param mixed   $value   Cookie value
      * @param integer $exp     Time to live
      * @param array   $options set_cookie options
-     * 
-     * @return $this 
+     *
+     * @return $this
      */
     public function set_cookie($name, $value, $exp = 3600, array $options = []) {
         $cookie_options = [
@@ -41,33 +41,10 @@ class Cookie {
             'secure' => true
         ];
 
-        self::setcookie73($name, $value, array_merge($cookie_options, $same_site_options, $options));
+        setcookie($name, $value, array_merge($cookie_options, $same_site_options, $options));
 
         // Set a second fallback cookie in the event that "SameSite" is not supported
-        self::setcookie73("LEGACY_" . $name, $value, array_merge($cookie_options, $options));
+        setcookie("LEGACY_" . $name, $value, array_merge($cookie_options, $options));
         return $this;
-    }
-
-    /**
-     * Add support for the PHP7.3+ `setcookie` with options, in a <PHP7.3-friendly way
-     * 
-     * @param string $name    The name of the cookie to set
-     * @param mixed  $value   The cookie value 
-     * @param array  $options Cookie options
-     * 
-     * @return void
-     */
-    private static function setcookie73($name, $value, array $options) {
-        $expires = isset($options['expires']) ? $options['expires'] : 0;
-        $path = isset($options['path']) ? $options['path'] : '/';
-        $domain = isset($options['domain']) ? $options['domain'] : '';
-        $secure = isset($options['secure']) ? $options['secure'] : false;
-        $httponly = isset($options['httponly']) ? $options['httponly'] : false;
-
-        // samesite can only be represented as a hack before PHP7.3
-        $samesite = isset($options['samesite']) ? $options['samesite'] : null;
-        $pathWithSamesiteHack = is_null($samesite) ? $path : "$path; SameSite=$samesite";
-
-        setcookie($name, $value, $expires, $pathWithSamesiteHack, $domain, $secure, $httponly);
     }
 }


### PR DESCRIPTION
* Related to TARL PHP7 upgrade ([PLT-244](https://techfromsage.atlassian.net/browse/PLT-244)).
* Restore the Cookie class implementation to the [original](https://github.com/1EdTech/lti-1-3-php-library/blob/3a192de99f3783d76caea462b0d04db28569c123/src/lti/Cookie.php).
* Bump minimum required PHP version to 7.3 (where `setcookie` function supports an array of options as argument).
* Remove PHP 5.5, 7.0 builds.